### PR TITLE
Add GitHub Action to deploy to GitHub Pages

### DIFF
--- a/.github/workflows/githubpages.yml
+++ b/.github/workflows/githubpages.yml
@@ -1,0 +1,24 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v2.3.1
+
+      - name: Install and Build 🔧 
+        run: |
+          npm install
+          npm run build
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: public # The folder the action should deploy.

--- a/public/index.html
+++ b/public/index.html
@@ -7,13 +7,13 @@
 
 	<title>Svelte app</title>
 
-	<link rel='icon' type='image/png' href='/favicon.png'>
+	<link rel='icon' type='image/png' href='favicon.png'>
 	<link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/@observablehq/inspector@3/dist/inspector.css">
 
-	<link rel='stylesheet' href='/global.css'>
-	<link rel='stylesheet' href='/build/bundle.css'>
+	<link rel='stylesheet' href='global.css'>
+	<link rel='stylesheet' href='build/bundle.css'>
 
-	<script defer src='/build/bundle.js'></script>
+	<script defer src='build/bundle.js'></script>
 </head>
 
 <body>


### PR DESCRIPTION
This PR contributes a GitHub Action which will deploy this to the `gh-pages` branch.  

Once merged and the action is first run, the `gh-pages` branch will be created.  You can then go to [GitHub Pages settings](https://github.com/graeme-lockley/notebook-viewer-2/settings/pages) and set your source to be `gh-pages` and hit "Save"

That's it!